### PR TITLE
ilspymcp.server as dotnet tool 🚀

### DIFF
--- a/ILSpy.Mcp.csproj
+++ b/ILSpy.Mcp.csproj
@@ -2,9 +2,22 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- NuGet dotnet tool packaging -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>ilspy-mcp</ToolCommandName>
+    <PackageId>ILSpyMcp.Server</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Gentledepp</Authors>
+    <Description>MCP server for .NET assembly decompilation and analysis using ILSpy. Enables AI assistants to decompile types, methods, list assembly types, analyze architecture, find type hierarchies, and search members in compiled .NET assemblies.</Description>
+    <PackageProjectUrl>https://github.com/gentledepp/ILSpy-Mcp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/gentledepp/ILSpy-Mcp.git</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>mcp;ilspy;decompiler;dotnet;analysis;ai</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +25,11 @@
     <Content Remove="Tests/**" />
     <EmbeddedResource Remove="Tests/**" />
     <None Remove="Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MCP.md
+++ b/MCP.md
@@ -1,47 +1,60 @@
 # ILSpy MCP Server - Connection Guide
 
-This guide explains how to connect the ILSpy MCP server to Cursor.
+This guide explains how to connect the ILSpy MCP server to various MCP clients.
 
 ## Prerequisites
 
-- .NET 8.0 SDK installed
-- Cursor IDE with MCP support
+- .NET 9.0 SDK installed
+- An MCP-compatible client (Claude Code, Cursor, Claude Desktop)
 
-## Building the Server
+## Installation
 
-1. Navigate to the project directory:
-   ```bash
-   cd C:\Users\Admin\Desktop\Dev\ILSpy-Mcp
-   ```
+Install as a global dotnet tool:
 
-2. Build the project in Release mode:
-   ```bash
-   dotnet build -c Release
-   ```
+```bash
+dotnet tool install -g ILSpyMcp.Server
+```
 
-3. The compiled executable will be located at:
-   ```
-   bin\Release\net8.0\ILSpy.Mcp.dll
-   ```
+Verify the installation:
 
-## Adding to Cursor MCP Configuration
+```bash
+ilspy-mcp --help
+```
 
-1. Open your Cursor MCP configuration file:
-   ```
-   C:\Users\Admin\.cursor\mcp.json
-   ```
+## Client Configuration
 
-2. Add the following entry to the `mcpServers` object:
+### Claude Code
+
+Register the server globally:
+
+```bash
+claude mcp add ilspy-mcp --command "ilspy-mcp" --scope user
+```
+
+Or per-project — create/update `.mcp.json` in the repo root:
 
 ```json
 {
   "mcpServers": {
-    "ilspy": {
-      "command": "dotnet",
-      "args": [
-        "C:\\Users\\Admin\\Desktop\\Dev\\ILSpy-Mcp\\bin\\Release\\net8.0\\ILSpy.Mcp.dll"
-      ],
-      "cwd": "C:\\Users\\Admin\\Desktop\\Dev\\ILSpy-Mcp",
+    "ilspy-mcp": {
+      "type": "stdio",
+      "command": "ilspy-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to your Cursor MCP configuration (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ilspy-mcp": {
+      "command": "ilspy-mcp",
+      "args": [],
       "env": {
         "ILSpy__MaxDecompilationSize": "1048576",
         "ILSpy__DefaultTimeoutSeconds": "30",
@@ -63,35 +76,28 @@ This guide explains how to connect the ILSpy MCP server to Cursor.
 }
 ```
 
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ilspy-mcp": {
+      "command": "ilspy-mcp",
+      "args": []
+    }
+  }
+}
+```
+
 ## Configuration Options
 
-The server can be configured via environment variables (as shown above) or via `appsettings.json`:
+The server can be configured via environment variables:
 
 - `ILSpy__MaxDecompilationSize`: Maximum size of decompiled code in bytes (default: 1048576 = 1 MB)
 - `ILSpy__DefaultTimeoutSeconds`: Default timeout for operations in seconds (default: 30)
 - `ILSpy__MaxConcurrentOperations`: Maximum number of concurrent operations (default: 10)
-
-## Alternative: Using Executable (Self-Contained)
-
-If you prefer to publish as a self-contained executable:
-
-1. Publish the application:
-   ```bash
-   dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
-   ```
-
-2. Use the executable path in `mcp.json`:
-   ```json
-   {
-     "mcpServers": {
-       "ilspy": {
-         "command": "C:\\Users\\Admin\\Desktop\\Dev\\ILSpy-Mcp\\bin\\Release\\net8.0\\win-x64\\publish\\ILSpy.Mcp.exe",
-         "args": [],
-         "env": {}
-       }
-     }
-   }
-   ```
 
 ## Available Tools
 
@@ -108,32 +114,28 @@ Once connected, the following tools will be available:
 
 ## Usage Example
 
-After adding the server to your configuration:
+After configuring, the server is available immediately. You can use tools like:
 
-1. Restart Cursor to load the new MCP server
-2. The server will be available in the MCP tools panel
-3. You can use tools like:
-   ```
-   decompile_type(
-     assemblyPath: "C:\\path\\to\\assembly.dll",
-     typeName: "System.String",
-     query: "What methods are available?"
-   )
-   ```
+```
+decompile_type(
+  assemblyPath: "/path/to/assembly.dll",
+  typeName: "System.String",
+  query: "What methods are available?"
+)
+```
 
 ## Troubleshooting
 
 ### Server Not Starting
 
-- Verify .NET 8.0 SDK is installed: `dotnet --version`
-- Check the build output directory exists
-- Review Cursor's MCP logs for error messages
+- Verify .NET 9.0 SDK is installed: `dotnet --version`
+- Verify the tool is installed: `dotnet tool list -g | grep ILSpyMcp`
+- Try reinstalling: `dotnet tool uninstall -g ILSpyMcp.Server && dotnet tool install -g ILSpyMcp.Server`
 
 ### Tools Not Available
 
-- Ensure the server is not disabled in `mcp.json`
-- Check that `autoApprove` includes the tool names
-- Verify the server started successfully in Cursor's MCP panel
+- Check that the MCP server is registered: run `/mcp` in Claude Code
+- Verify the server started successfully in your client's MCP panel
 
 ### Timeout Errors
 
@@ -145,9 +147,18 @@ After adding the server to your configuration:
 - All operations are **read-only** (no file modifications)
 - Assembly paths are validated before processing
 - Operations have timeout protection to prevent resource exhaustion
-- Consider restricting access to specific assembly directories if needed
+
+## Updating
+
+```bash
+dotnet tool update -g ILSpyMcp.Server
+```
 
 ## Logging
 
-Logs are written to stderr and can be viewed in Cursor's MCP server logs. To adjust log levels, you can modify the logging configuration in `appsettings.json` or via environment variables.
+Logs are written to stderr. To adjust log levels, set environment variables:
 
+```bash
+Logging__LogLevel__Default=Information
+Logging__LogLevel__ILSpy.Mcp=Debug
+```

--- a/README.md
+++ b/README.md
@@ -2,62 +2,84 @@
 
 A Model Context Protocol (MCP) server that provides .NET assembly decompilation and analysis capabilities.
 
-## 🎯 What is this?
+## What is this?
 
-ILSpy MCP Server enables AI assistants (like Claude Desktop, Cursor) to decompile and analyze .NET assemblies directly through natural language commands. It integrates [ILSpy](https://github.com/icsharpcode/ILSpy) to provide powerful reverse-engineering capabilities.
+ILSpy MCP Server enables AI assistants (like Claude Code, Cursor) to decompile and analyze .NET assemblies directly through natural language commands. It integrates [ILSpy](https://github.com/icsharpcode/ILSpy) to provide powerful reverse-engineering capabilities.
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Prerequisites
 
-- .NET 8.0 or higher
-- ILSpy installed or ILSpy CLI available
-- MCP-compatible client (Cursor, Claude Desktop, etc.)
+- .NET 9.0 SDK or higher
+- MCP-compatible client (Claude Code, Cursor, Claude Desktop, etc.)
 
 ### Installation
 
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/bivex/ILSpy-Mcp.git
-   cd ILSpy-Mcp
-   ```
+Install as a global dotnet tool from NuGet:
 
-2. **Build the project:**
-   ```bash
-   dotnet build -c Release
-   ```
+```bash
+dotnet tool install -g ILSpyMcp.Server
+```
 
-3. **Configure MCP Client:**
+To update to the latest version:
 
-   For **Claude Desktop**, add to `claude_desktop_config.json`:
-   ```json
-   {
-     "mcpServers": {
-       "ilspy-mcp": {
-         "command": "dotnet",
-         "args": ["/path/to/ILSpy-Mcp.dll"]
-       }
-     }
-   }
-   ```
+```bash
+dotnet tool update -g ILSpyMcp.Server
+```
 
-   For **Cursor**, configure in MCP settings:
-   ```json
-   {
-     "servers": {
-       "ilspy-mcp": {
-         "command": "dotnet",
-         "args": ["/path/to/ILSpy-Mcp.dll"]
-       }
-     }
-   }
-   ```
+### Configure MCP Client
+
+For **Claude Code**, register the MCP server:
+
+```bash
+claude mcp add ilspy-mcp --command "ilspy-mcp" --scope user
+```
+
+Or create/update `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "ilspy-mcp": {
+      "type": "stdio",
+      "command": "ilspy-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+For **Cursor**, add to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "ilspy-mcp": {
+      "command": "ilspy-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+For **Claude Desktop**, add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ilspy-mcp": {
+      "command": "ilspy-mcp",
+      "args": []
+    }
+  }
+}
+```
 
 ## Usage Examples
 
-### Decompile an Assembly
+### Decompile a Type
 ```
-Decompile the assembly /path/to/MyAssembly.dll and show me the Main method
+Decompile the String class from /path/to/System.Runtime.dll
 ```
 
 ### List All Types
@@ -67,7 +89,7 @@ List all types in the assembly /path/to/MyLibrary.dll
 
 ### Find a Specific Method
 ```
-Find the CalculateTotal method in the assembly /path/to/Calculator.dll
+Find the CalculateTotal method in /path/to/Calculator.dll
 ```
 
 ### Analyze Type Hierarchy
@@ -80,6 +102,27 @@ Show me the type hierarchy for ProductService in /path/to/ECommerce.dll
 Search for members containing "Authenticate" in /path/to/Auth.dll
 ```
 
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `decompile_type` | Decompile and analyze a .NET type from a DLL |
+| `decompile_method` | Decompile and analyze a specific method |
+| `list_assembly_types` | List all types in an assembly |
+| `analyze_assembly` | Get architectural overview of an assembly |
+| `get_type_members` | Get complete API surface of a type |
+| `find_type_hierarchy` | Find inheritance relationships |
+| `search_members_by_name` | Search for members by name |
+| `find_extension_methods` | Find extension methods for a type |
+
+## Configuration
+
+The server can be configured via environment variables:
+
+- `ILSpy__MaxDecompilationSize`: Maximum size of decompiled code in bytes (default: 1048576 = 1 MB)
+- `ILSpy__DefaultTimeoutSeconds`: Default timeout for operations in seconds (default: 30)
+- `ILSpy__MaxConcurrentOperations`: Maximum number of concurrent operations (default: 10)
+
 ## Architecture
 
 This server follows a clean architecture with clear separation of concerns:
@@ -89,19 +132,6 @@ This server follows a clean architecture with clear separation of concerns:
 - **Infrastructure**: External system adapters (ILSpy, file system)
 - **Transport**: MCP protocol layer
 
-## Capabilities
-
-- Decompile types, methods, and assemblies
-- List and search types in assemblies
-- Analyze assembly structure and architecture
-- Find type hierarchies and relationships
-- Discover extension methods
-- Search members by name
-
-## Configuration
-
-Configuration is managed through environment variables and `appsettings.json`.
-
 ## Security
 
 - All operations are read-only (no file modifications)
@@ -109,12 +139,6 @@ Configuration is managed through environment variables and `appsettings.json`.
 - Timeout and cancellation support
 - Request context propagation
 
-## Requirements
-
-- .NET 8.0+
-- ILSpy or ILSpy CLI
-- MCP-compatible client
-
 ## License
 
-See LICENSE file for details.
+MIT — see [LICENSE](LICENSE) for details.

--- a/Tests/ILSpy.Mcp.Tests.csproj
+++ b/Tests/ILSpy.Mcp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This changes the project so that you can actually publish it as a dotnet tool, which makes it easier to install.

For example, I set up an ilspy-mcp skill here: https://github.com/gentledepp/dotnet-skills/tree/main/plugins/dotnet-skills/skills/ilspy-mcp

I published the dotnet tool https://www.nuget.org/packages/ILSpyMcp.Server/1.0.0/Manage
but I am happy to add you as the owner (give you ownership) if you like